### PR TITLE
Add internal function support for callbacks

### DIFF
--- a/CLanguage/Compiler/EmitContext.cs
+++ b/CLanguage/Compiler/EmitContext.cs
@@ -130,6 +130,9 @@ namespace CLanguage.Compiler
             else if (fromType is CEnumType et && toType is CIntType bt) {
                 // Enums act like ints
             }
+            else if (fromType is CFunctionType fft && toType is CFunctionType tft) {
+                // Function to function is OK
+            }
             else {
                 Report.Error (30, "Cannot convert type '" + fromType + "' to '" + toType + "'");
             }

--- a/CLanguage/Compiler/ResolvedVariable.cs
+++ b/CLanguage/Compiler/ResolvedVariable.cs
@@ -35,6 +35,29 @@ namespace CLanguage.Compiler
             VariableType = variableType;
         }
 
+        public void Emit (EmitContext ec)
+        {
+            switch (Scope) {
+                case VariableScope.Function:
+                    ec.Emit (OpCode.LoadConstant, Value.Pointer (Address));
+                    break;
+                case VariableScope.Global:
+                    ec.Emit (OpCode.LoadGlobal, Value.Pointer (Address));
+                    break;
+                case VariableScope.Arg:
+                    ec.Emit (OpCode.LoadArg, Value.Pointer (Address));
+                    break;
+                case VariableScope.Local:
+                    ec.Emit (OpCode.LoadLocal, Value.Pointer (Address));
+                    break;
+                case VariableScope.Constant:
+                    ec.Emit (OpCode.LoadConstant, 0);
+                    break;
+                default:
+                    throw new NotSupportedException ("Cannot get value of variable scope '" + Scope + "'");
+            }
+        }
+
         public void EmitPointer (EmitContext ec)
         {
             switch (Scope) {

--- a/CLanguage/Interpreter/CInterpreter.cs
+++ b/CLanguage/Interpreter/CInterpreter.cs
@@ -24,6 +24,8 @@ namespace CLanguage.Interpreter
 
         public ExecutionFrame? ActiveFrame { get { return (0 <= FI && FI < Frames.Length) ? Frames[FI] : null; } }
 
+        public int CallStackDepth => FI;
+
         static readonly BaseFunction unusedStackFrameFunction = new InternalFunction ("unused", "", Types.CFunctionType.VoidProcedure);
 
 

--- a/CLanguage/Interpreter/CompiledFunction.cs
+++ b/CLanguage/Interpreter/CompiledFunction.cs
@@ -60,7 +60,7 @@ namespace CLanguage.Interpreter
 
                 var i = Instructions[ip];
 
-                //Debug.WriteLine (i);
+                //Debug.WriteLine (new string(' ', 4*state.CallStackDepth) + i + " ;" + state.ActiveFrame?.Function.Name);
 
                 if (state.SP < frame.FP)
                     throw new Exception ($"{(ip - 1 >= 0 ? Instructions[ip - 1] : null)} {this.Name}@{ip - 1} stack underflow");

--- a/CLanguage/Syntax/FuncallExpression.cs
+++ b/CLanguage/Syntax/FuncallExpression.cs
@@ -148,7 +148,7 @@ namespace CLanguage.Syntax
                 if (res != null) {
                     return new Overload (
                         res.VariableType,
-                        res.EmitPointer);
+                        res.VariableType is CFunctionType ? (Action<EmitContext>)res.Emit : res.EmitPointer);
                 }
                 else {
                     return Overload.Error;

--- a/CLanguageTests/ArduinoInterpreterTests.cs
+++ b/CLanguageTests/ArduinoInterpreterTests.cs
@@ -117,6 +117,42 @@ void loop() {
         }
 
         [TestMethod]
+        public void VoidCallbackTest ()
+        {
+            var code = @"
+int result = 0;
+void callback(int x, int y) {
+  result = x*1000 + y;
+}
+void setup() {
+  voidCallbackTest(callback, 2, 3);
+}
+void loop() {
+  Serial.println(result);
+}";
+            var arduino = Run (code);
+            Assert.AreEqual ("2003", arduino.SerialOut.ToString ().Split ("\n").First ().Trim ());
+        }
+
+        [TestMethod]
+        public void IntCallbackTest ()
+        {
+            var code = @"
+int result = 0;
+int callback(int x, int y) {
+  return x*100 + y;
+}
+void setup() {
+  result = intCallbackTest(callback, 2, 3);
+}
+void loop() {
+  Serial.println(result);
+}";
+            var arduino = Run (code);
+            Assert.AreEqual ("203", arduino.SerialOut.ToString ().Split ("\n").First ().Trim ());
+        }
+
+        [TestMethod]
         public void AnalogReadSerial ()
         {
             var code = @"

--- a/CLanguageTests/ArduinoTestMachineInfo.cs
+++ b/CLanguageTests/ArduinoTestMachineInfo.cs
@@ -92,6 +92,19 @@ struct CtorTest {
                 var arg = x.ReadArg (0);
                 x.Stack[_this] = arg;
             });
+            AddInternalFunction ("void voidCallbackTest (void (*callback)(int x, int y), int xx, int yy)", x => {
+                var callback = x.ReadArg (0);
+                var xx = x.ReadArg (1);
+                var yy = x.ReadArg (2);
+                x.RunFunction (callback, xx, yy, 1_000_000);
+            });
+            AddInternalFunction ("int intCallbackTest (int (*callback)(int x, int y), int xx, int yy)", x => {
+                var callback = x.ReadArg (0);
+                var xx = x.ReadArg (1);
+                var yy = x.ReadArg (2);
+                var result = x.RunFunction (callback, xx, yy, 1_000_000);
+                x.Push (result);
+            });
         }
 
         public override ResolvedVariable GetUnresolvedVariable (string name, CType[] argTypes, EmitContext context)

--- a/CLanguageTests/InterpreterTests.cs
+++ b/CLanguageTests/InterpreterTests.cs
@@ -8,45 +8,45 @@ namespace CLanguage.Tests
 	[TestClass]
 	public class InterpreterTests : TestsBase
 	{
-        [TestMethod]
-        public void YieldingDelay ()
-        {
-            var mi = new TestMachineInfo ();
-            bool[] hit = new bool[3];
-            mi.AddInternalFunction ("int yieldingDelay(int ms)", i => {
-                var ms = i.ReadArg (0).Int16Value;
-                Console.WriteLine ($"RUN Y={i.YieldedValue}");
-                hit[i.YieldedValue] = true;
-                if (i.YieldedValue == 0) {
-                    i.Yield (1);
-                }
-                else if (i.YieldedValue == 1) {
-                    i.Yield (2);
-                }
-                else {
-                    i.Yield (0);
-                    i.Push (ms * 1000);
-                }
-            });
-            var it = Run (@"
+		[TestMethod]
+		public void YieldingDelay ()
+		{
+			var mi = new TestMachineInfo ();
+			bool[] hit = new bool[3];
+			mi.AddInternalFunction ("int yieldingDelay(int ms)", i => {
+				var ms = i.ReadArg (0).Int16Value;
+				Console.WriteLine ($"RUN Y={i.YieldedValue}");
+				hit[i.YieldedValue] = true;
+				if (i.YieldedValue == 0) {
+					i.Yield (1);
+				}
+				else if (i.YieldedValue == 1) {
+					i.Yield (2);
+				}
+				else {
+					i.Yield (0);
+					i.Push (ms * 1000);
+				}
+			});
+			var it = Run (@"
 void main () {
     auto x = yieldingDelay(3);
     assertAreEqual (3000, x);
 }", mi);
-            Assert.IsTrue (hit[0]);
-            Assert.IsFalse (hit[1]);
-            Assert.IsFalse (hit[2]);
-            it.Step ();
-            Assert.IsTrue (hit[0]);
-            Assert.IsTrue (hit[1]);
-            Assert.IsFalse (hit[2]);
-            it.Step ();
-            Assert.IsTrue (hit[0]);
-            Assert.IsTrue (hit[1]);
-            Assert.IsTrue (hit[2]);
-        }
+			Assert.IsTrue (hit[0]);
+			Assert.IsFalse (hit[1]);
+			Assert.IsFalse (hit[2]);
+			it.Step ();
+			Assert.IsTrue (hit[0]);
+			Assert.IsTrue (hit[1]);
+			Assert.IsFalse (hit[2]);
+			it.Step ();
+			Assert.IsTrue (hit[0]);
+			Assert.IsTrue (hit[1]);
+			Assert.IsTrue (hit[2]);
+		}
 
-        [TestMethod]
+		[TestMethod]
 		public void InfiniteRecursionThrows ()
 		{
 			try {
@@ -389,22 +389,22 @@ void main () {
 }");
 		}
 
-        [TestMethod]
-        public void GlobalVariableInitialization ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void GlobalVariableInitialization ()
+		{
+			var i = Run (@"
 int a = 4;
 int b = 8;
 int c = a + b;
 void main () {
     assertAreEqual (12, c);
 }");
-        }
+		}
 
-        [TestMethod]
-        public void AddressOfLocal ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void AddressOfLocal ()
+		{
+			var i = Run (@"
 void main () {
     int a = 4;
     int *pa = &a;
@@ -412,12 +412,12 @@ void main () {
     a = *pa + 1;
     assertAreEqual (5, *pa);
 }");
-        }
+		}
 
-        [TestMethod]
-        public void AddressOfGlobal ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void AddressOfGlobal ()
+		{
+			var i = Run (@"
 int a = 0;
 void main () {
     int *pa = &a;
@@ -425,49 +425,49 @@ void main () {
     a = *pa + 1;
     assertAreEqual (1, *pa);
 }");
-        }
+		}
 
-        [TestMethod]
-        public void PreDecrement ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void PreDecrement ()
+		{
+			var i = Run (@"
 void main () {
     int a = 100;
     assertAreEqual (99, --a);
 }");
-        }
+		}
 
-        [TestMethod]
-        public void PreIncrement ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void PreIncrement ()
+		{
+			var i = Run (@"
 void main () {
     int a = 100;
     assertAreEqual (101, ++a);
 }");
-        }
+		}
 
-        [TestMethod]
-        public void PostDecrement ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void PostDecrement ()
+		{
+			var i = Run (@"
 void main () {
     int a = 100;
     assertAreEqual (100, a--);
     assertAreEqual (99, a);
 }");
-        }
+		}
 
-        [TestMethod]
-        public void PostIncrement ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void PostIncrement ()
+		{
+			var i = Run (@"
 void main () {
     int a = 100;
     assertAreEqual (100, a++);
     assertAreEqual (101, a);
 }");
-        }
+		}
 
 		[TestMethod]
 		public void PostIncrementPointer ()
@@ -496,9 +496,9 @@ void main () {
 		}
 
 		[TestMethod]
-        public void BoolAssignment ()
-        {
-            var i = Run (@"
+		public void BoolAssignment ()
+		{
+			var i = Run (@"
 void main () {
     bool a = false;
     assertAreEqual (false, a);
@@ -507,12 +507,12 @@ void main () {
     assertAreEqual (true, a);
     assertAreEqual ((bool)1, a);
 }");
-        }
+		}
 
-        [TestMethod]
-        public void BoolLoopEnd ()
-        {
-            var i = Run (@"
+		[TestMethod]
+		public void BoolLoopEnd ()
+		{
+			var i = Run (@"
 void main () {
     int i = 0;
     bool b = true;
@@ -523,7 +523,7 @@ void main () {
     assertAreEqual (false, b);
     assertAreEqual (10, i);
 }");
-        }
+		}
 
 		[TestMethod]
 		public void ArrayElementAssignment ()
@@ -564,6 +564,41 @@ void main () {
 	assertAreEqual (33, c);
 	assign(&c);
 	assertAreEqual (42, c);
+}
+");
+		}
+
+		[TestMethod]
+		public void VoidCallbackFunction ()
+		{
+			Run (@"
+int result = 0;
+void callback(int x) {
+	result = 10 * x;
+}
+void callCallback(void (*cb)(int), int cbx) {
+	cb(cbx);
+}
+void main () {
+	callCallback(callback, 12);
+	assertAreEqual(120, result);
+}
+");
+		}
+
+		[TestMethod]
+		public void IntCallbackFunction ()
+		{
+			Run (@"
+int callback(int x) {
+	return 10 * x;
+}
+int callCallback(int (*cb)(int), int cbx) {
+	return cb(cbx);
+}
+void main () {
+	int result = callCallback(callback, 123);
+	assertAreEqual(1230, result);
 }
 ");
 		}

--- a/Editor/iOS/CLanguage.Editor.iOS.csproj
+++ b/Editor/iOS/CLanguage.Editor.iOS.csproj
@@ -86,5 +86,8 @@
       <Name>CLanguage</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Editor/iOS/Info.plist
+++ b/Editor/iOS/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
This PR fixes internal callback support and adds the `RunFunction` method to the interpreter to call callback code from internal functions.

Example:

```csharp
AddInternalFunction ("int intCallbackTest (int (*callback)(int x, int y), int xx, int yy)", x => {
                var callback = x.ReadArg (0);
                var xx = x.ReadArg (1);
                var yy = x.ReadArg (2);
                var result = x.RunFunction (callback, xx, yy, 1_000_000);
                x.Push (result);
});
```

The entire callback function must execute and return before the internal function returns (mixed stacks aren't supported). This can result in deadlocks if user code has infinite loops.

To combat this, the last parameter specifies the max amount of CPU time that can occur before returning. If the function is aborted, it returns `0`.
