### PR TITLE
Support low level memory functions using void*

### DIFF
--- a/.github/workflows/build-nugets.yml
+++ b/.github/workflows/build-nugets.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Update Versions
       env:
-        VERSION_PREFIX: 0.19
+        VERSION_PREFIX: 0.20
         VERSION_SUFFIX: ${{github.run_number}}
       run: |
         VERSION=$VERSION_PREFIX.$VERSION_SUFFIX

--- a/.github/workflows/build-nugets.yml
+++ b/.github/workflows/build-nugets.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Update Versions
       env:
         VERSION_PREFIX: 0.20
@@ -23,7 +23,7 @@ jobs:
         sed -i bak "s:<version>1.0.0</version>:<version>$VERSION</version>:g" CLanguage.Editor.nuspec
         sed -i bak2 "s:version=\"1.0.0\":version=\"$VERSION\":g" CLanguage.Editor.nuspec
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.300
     - name: Install dependencies
@@ -39,13 +39,16 @@ jobs:
     - name: Build iOS Editor
       run: msbuild /p:Configuration=Release Editor/iOS/CLanguage.Editor.iOS.csproj
     - name: Package Library
+      if: github.event_name == 'push'
       run: |
         mkdir PackageOut
         cd CLanguage && dotnet pack --include-symbols --no-build -c Release -v normal -o ../PackageOut
     - name: Package Editor
+      if: github.event_name == 'push'
       run: |
         nuget pack CLanguage.Editor.nuspec -OutputDirectory PackageOut
     - name: Package
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@master
       with:
         path: PackageOut

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # Test files
 
 CLanguageTests/a.out
-CLanguageTests/test.c
+CLanguageTests/test*.c
 
 
 /*.nupkg

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "cmake.configureOnOpen": false
+    "cmake.configureOnOpen": false,
+    "dotnet.preferCSharpExtension": true
 }

--- a/CLanguage/Compiler/EmitContext.cs
+++ b/CLanguage/Compiler/EmitContext.cs
@@ -122,11 +122,17 @@ namespace CLanguage.Compiler
                 Emit (op);
                 // This conversion is implicit with how the evaluator stores its stuff
             }
-            else if (fromBasicType != null && fromBasicType.IsIntegral && toType is CPointerType && fromBasicType.NumValues == toType.NumValues) {
+            else if (fromBasicType != null && fromBasicType.IsIntegral && toType is CPointerType) {
                 // Support `const char *p = 0;`
             }
             else if (fromType is CArrayType fat && toType is CPointerType tpt && fat.ElementType.NumValues == tpt.InnerType.NumValues) {
                 // Demote arrays to pointers
+            }
+            else if (fromType is CArrayType && toType.IsVoidPointer) {
+                // Demote arrays to void pointers without size check. Better hope sizeof works.
+            }
+            else if (fromType.IsPointer && toType.IsVoidPointer) {
+                // Demote pointers to void pointers without size check. Better hope sizeof works.
             }
             else if (fromType is CEnumType et && toType is CIntType bt) {
                 // Enums act like ints

--- a/CLanguage/Compiler/EmitContext.cs
+++ b/CLanguage/Compiler/EmitContext.cs
@@ -129,10 +129,10 @@ namespace CLanguage.Compiler
                 // Demote arrays to pointers
             }
             else if (fromType is CArrayType && toType.IsVoidPointer) {
-                // Demote arrays to void pointers without size check. Better hope sizeof works.
+                // Demote arrays to void pointers without size check. sizeof() reports type.NumValues.
             }
             else if (fromType.IsPointer && toType.IsVoidPointer) {
-                // Demote pointers to void pointers without size check. Better hope sizeof works.
+                // Demote pointers to void pointers without size check. sizeof() reports type.NumValues.
             }
             else if (fromType is CEnumType et && toType is CIntType bt) {
                 // Enums act like ints

--- a/CLanguage/Interpreter/CInterpreter.cs
+++ b/CLanguage/Interpreter/CInterpreter.cs
@@ -42,6 +42,11 @@ namespace CLanguage.Interpreter
             return Stack[address];
         }
 
+        public Value WriteMemory (int address, Value value)
+        {
+            return Stack[address] = value;
+        }
+
         public string ReadStringWithEncoding (int address, Encoding encoding)
         {
             var b = (byte)Stack[address];

--- a/CLanguage/Syntax/SizeOfExpression.cs
+++ b/CLanguage/Syntax/SizeOfExpression.cs
@@ -25,7 +25,7 @@ namespace CLanguage.Syntax
         protected override void DoEmit(EmitContext ec)
         {
             var type = Query.GetEvaluatedCType (ec);
-            Value cval = type.GetByteSize (ec);
+            Value cval = type.NumValues;
             ec.Emit (OpCode.LoadConstant, cval);
         }
     }

--- a/CLanguage/Syntax/SizeOfTypeExpression.cs
+++ b/CLanguage/Syntax/SizeOfTypeExpression.cs
@@ -22,7 +22,7 @@ namespace CLanguage.Syntax
         protected override void DoEmit (EmitContext ec)
         {
             var type = ec.ResolveTypeName (TypeName);
-            Value cval = type.GetByteSize (ec);
+            Value cval = type.NumValues;
             ec.Emit (OpCode.LoadConstant, cval);
         }
     }

--- a/CLanguage/Types/CType.cs
+++ b/CLanguage/Types/CType.cs
@@ -24,6 +24,16 @@ namespace CLanguage.Types
 
         public CPointerType Pointer => pointer.Value;
 
+        public bool IsVoidPointer => this switch {
+            CPointerType pt => pt.InnerType.IsVoid || pt.InnerType.IsVoidPointer,
+            _ => false,
+        };
+
+        public bool IsPointer => this switch {
+            CPointerType pt => true,
+            _ => false,
+        };
+
         public CType ()
         {
             pointer = new Lazy<CPointerType> (CreatePointerType);

--- a/CLanguageTests/ArduinoInterpreterTests.cs
+++ b/CLanguageTests/ArduinoInterpreterTests.cs
@@ -21,7 +21,7 @@ namespace CLanguage.Tests
             var fullCode = code + "\n\nvoid main() { __cinit(); setup(); while(1){loop();}}";
             var i = CLanguageService.CreateInterpreter (fullCode, machine, new TestPrinter ());
             i.Reset ("main");
-            i.Step ();
+            i.Run ();
             return machine.Arduino;
         }
 

--- a/CLanguageTests/ArrayTests.cs
+++ b/CLanguageTests/ArrayTests.cs
@@ -13,7 +13,7 @@ namespace CLanguage.Tests
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new ArduinoTestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 

--- a/CLanguageTests/CastTests.cs
+++ b/CLanguageTests/CastTests.cs
@@ -13,7 +13,7 @@ namespace CLanguage.Tests
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new ArduinoTestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 

--- a/CLanguageTests/ClassTests.cs
+++ b/CLanguageTests/ClassTests.cs
@@ -33,8 +33,8 @@ typedef class C {
 } OtherC;
 OtherC c;
 void main() {
-    assertAreEqual(2, sizeof(c));
-    assertAreEqual(2, sizeof(OtherC));
+    assertAreEqual(1, sizeof(c));
+    assertAreEqual(1, sizeof(OtherC));
 }
 ");
         }

--- a/CLanguageTests/FloatTests.cs
+++ b/CLanguageTests/FloatTests.cs
@@ -14,7 +14,7 @@ namespace CLanguage.Tests
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new ArduinoTestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 

--- a/CLanguageTests/IntegerTests.cs
+++ b/CLanguageTests/IntegerTests.cs
@@ -250,7 +250,7 @@ namespace CLanguage.Tests
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new ArduinoTestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 

--- a/CLanguageTests/InterpreterTests.cs
+++ b/CLanguageTests/InterpreterTests.cs
@@ -330,7 +330,7 @@ void main () {
 			var i = Run (@"
 void main () {
 	int s = sizeof(int);
-	assertAreEqual (2, s);
+	assertAreEqual (1, s);
 }");
 		}
 
@@ -340,7 +340,7 @@ void main () {
 			var i = Run (@"
 void main () {
 	int s = sizeof(sizeof(int));
-	assertAreEqual (4, s);
+	assertAreEqual (1, s);
 }");
 		}
 
@@ -350,7 +350,7 @@ void main () {
 			var i = Run (@"
 void main () {
 	int s = sizeof(int*);
-	assertAreEqual (2, s);
+	assertAreEqual (1, s);
 }");
 		}
 
@@ -360,7 +360,7 @@ void main () {
 			var i = Run (@"
 void main () {
 	int s = sizeof(long int);
-	assertAreEqual (4, s);
+	assertAreEqual (1, s);
 }");
 		}
 
@@ -370,8 +370,10 @@ void main () {
 			var i = Run (@"
 int array[] = { 0, 1, 2, 3, 4 };
 void main () {
-	int num = sizeof(array) / sizeof(array[0]);
-    int num2 = sizeof(array) / sizeof(int);
+	int sa = sizeof(array);
+	assertAreEqual (5, sa);
+	int num = sa / sizeof(array[0]);
+    int num2 = sa / sizeof(int);
 	assertAreEqual (5, num);
     assertAreEqual (5, num2);
 }");

--- a/CLanguageTests/InterpreterTests.cs
+++ b/CLanguageTests/InterpreterTests.cs
@@ -380,6 +380,25 @@ void main () {
 		}
 
 		[TestMethod]
+		public void InternalFunctionMemcmpWorks ()
+		{
+			var i = Run (@"
+int memcmp (const void *s1, const void *s2, int n);
+int ones[5] = { 1, 1, 1, 1, 1 };
+int ones2[5] = { 1, 1, 1, 1, 1 };
+int twos[5] = { 2, 2, 2, 2, 2 };
+void main () {
+	assertAreEqual (0, memcmp(ones, ones2, sizeof(ones)));
+	assertAreEqual (0, memcmp(ones2, ones, sizeof(ones)));
+	assertAreEqual (0, memcmp(ones, ones, sizeof(ones)));
+	assertAreEqual (0, memcmp(ones2, ones2, sizeof(ones)));
+	assertAreEqual (0, memcmp(twos, twos, sizeof(twos)));
+	assertAreEqual (-1, memcmp(ones, twos, sizeof(ones)));
+	assertAreEqual (1, memcmp(twos, ones, sizeof(ones)));
+}");
+		}
+
+		[TestMethod]
 		public void LocalVariableInitialization ()
 		{
 			var i = Run (@"

--- a/CLanguageTests/LogicTests.cs
+++ b/CLanguageTests/LogicTests.cs
@@ -14,7 +14,7 @@ namespace CLanguage.Tests
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new ArduinoTestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 

--- a/CLanguageTests/OverloadTests.cs
+++ b/CLanguageTests/OverloadTests.cs
@@ -8,12 +8,12 @@ namespace CLanguage.Tests
     [TestClass]
     public class OverloadTests
     {
-        CInterpreter Run (string code)
+        static CInterpreter Run (string code)
         {
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new ArduinoTestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 
@@ -102,13 +102,28 @@ void main () {
         }
 
         [TestMethod]
-        public void PrintlnConstCharPtr ()
+        public void VoidPtrFromArray ()
         {
             var i = Run (@"
+int f(void *x) { return 1; }
+int xs[5] = { 10, 20, 30, 40, 50 };
 void main () {
-    Serial.println(""hello"");
+    int fr = f(xs);
+    assertAreEqual (1, fr);
 }");
-            Assert.AreEqual("hello\n", ((ArduinoTestMachineInfo)i.Executable.MachineInfo).Arduino.SerialOut.ToString());
+        }
+
+        [TestMethod]
+        public void VoidPtrFromOtherPtr ()
+        {
+            var i = Run (@"
+int f(void *x) { return 1; }
+int xs[5] = { 10, 20, 30, 40, 50 };
+void main () {
+    int *p = xs;
+    int fr = f(p);
+    assertAreEqual (1, fr);
+}");
         }
     }
 }

--- a/CLanguageTests/StringTests.cs
+++ b/CLanguageTests/StringTests.cs
@@ -13,7 +13,7 @@ namespace CLanguage.Tests
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new ArduinoTestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 

--- a/CLanguageTests/TestMachineInfo.cs
+++ b/CLanguageTests/TestMachineInfo.cs
@@ -32,6 +32,7 @@ namespace CLanguage.Tests
             AddInternalFunction ("void assertBoolsAreEqual (bool expected, bool actual)", AssertBoolsAreEqual);
             AddInternalFunction ("void assertFloatsAreEqual (float expected, float actual)", AssertFloatsAreEqual);
             AddInternalFunction ("void assertDoublesAreEqual (double expected, double actual)", AssertDoublesAreEqual);
+            AddInternalFunction ("int memcmp (void* s1, void* s2, int n)", Memcmp);
         }
 
         static void AssertAreEqual (CInterpreter state)
@@ -81,6 +82,25 @@ namespace CLanguage.Tests
             var expected = state.ReadArg (0);
             var actual = state.ReadArg (1);
             Assert.AreEqual ((int)expected, (int)actual);
+        }
+
+        static void Memcmp (CInterpreter interpreter)
+        {
+            var s1 = interpreter.ReadArg (0).PointerValue;
+            var s2 = interpreter.ReadArg (1).PointerValue;
+            var n = interpreter.ReadArg (2).UInt32Value;
+            while (n > 0) {
+                var v1 = interpreter.ReadMemory (s1).UInt8Value;
+                var v2 = interpreter.ReadMemory (s2).UInt8Value;
+                if (v1 != v2) {
+                    interpreter.Push (v1 - v2);
+                    return;
+                }
+                s1++;
+                s2++;
+                n--;
+            }
+            interpreter.Push (0);
         }
     }
 }

--- a/CLanguageTests/TestsBase.cs
+++ b/CLanguageTests/TestsBase.cs
@@ -21,7 +21,7 @@ namespace CLanguage.Tests
             var i = CLanguageService.CreateInterpreter (fullCode, mi ?? new TestMachineInfo (), printer: printer);
             printer.CheckForErrors ();
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 

--- a/CLanguageTests/TypedefTests.cs
+++ b/CLanguageTests/TypedefTests.cs
@@ -14,7 +14,7 @@ namespace CLanguage.Tests
             var fullCode = "void start() { __cinit(); main(); } " + code;
             var i = CLanguageService.CreateInterpreter (fullCode, new TestMachineInfo (), printer: new TestPrinter ());
             i.Reset ("start");
-            i.Step ();
+            i.Run ();
             return i;
         }
 


### PR DESCRIPTION
I want to implement `memcmp`, `memset`, etc so need `void*` to work. Also change `sizeof` to report `type.NumValues` instead of byte counts so that the correct values can be passed to low level memory functions like this.